### PR TITLE
Add attribute parser to node creation

### DIFF
--- a/src/DGDB.h
+++ b/src/DGDB.h
@@ -16,6 +16,7 @@
 #include <thread>
 #include <map>
 #include <vector>
+#include <algorithm>
 
 class DGDB {
  private:
@@ -85,8 +86,9 @@ class DGDB {
 
   // CRUD DGDB
   void setNode(std::string name);
-  void setRelation(std::string nameA, std::string nameB);
-  void createRelation(std::string nameA, std::string nameB, int conn=0);
+  void setRelation(std::vector<std::string> args);
+  void createRelation(std::string nameA, std::string nameB, int conn=0,
+                      std::vector<std::pair<std::string, std::string> > attributes = {});
 
   ///  Protocolo
   void createNode(std::string name, int conn=0);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,8 +6,12 @@ int main(int argc, char* argv[]) {
   if (argv[1][0] == 'C') {
     db.setMode('C');
     db.setClient();
-    //db.setNode(argv[2]);
-    db.setRelation(argv[2], argv[3]);
+    std::vector<std::string> args;
+    while(argc > 2) {
+      args.push_back(argv[argc-1]);
+      argc--;
+    }
+    db.setRelation(args);
   }
   else if (argv[1][0] == 'S') {
     db.setMode('S');


### PR DESCRIPTION
New format, add attributes with `-a` token:
```bash
$ ./dgdb C [nodeA] [-a][key=value]* [nodeB]
```
Real example: 
```bash
$ ./dgdb C joaquin -a nombre="Joaquin Palma" -a edad=19 mateo
```