### PR TITLE
Finished refactoring communication logic in DGDB & improved TCPSocket

### DIFF
--- a/src/DGDB.cpp
+++ b/src/DGDB.cpp
@@ -206,8 +206,8 @@ void DGDB::setClient() {
 
 void DGDB::closeClient() {
   connection = 0;
-  shutdown(socketCliente, SHUT_RDWR);
-  close(socketCliente);
+  client_socket.Shutdown(SHUT_RDWR);
+  client_socket.Close();
 }
 
 void DGDB::setServer() {
@@ -219,7 +219,7 @@ void DGDB::setServer() {
 
 void DGDB::closeServer() {
   server = 0;
-  close(socketServer);
+  server_socket.Close();
 }
 
 void DGDB::setRepository() {
@@ -233,7 +233,7 @@ void DGDB::setRepository() {
 }
 
 void DGDB::setNode(std::string name) {
-  createNode(name, socketCliente);
+  createNode(name, client_socket.GetSocketId());
 }
 
 void DGDB::setRelation(std::vector<std::string> args) {
@@ -344,7 +344,7 @@ void DGDB::createNode(std::string name, int conn) {
 
   if (n < 0) {
     perror("error listen failed");
-    close(socketCliente);
+    client_socket.Close();
     exit(EXIT_FAILURE);
   }
   else if (n > 0 && n != buffer.length()) {

--- a/src/DGDB.h
+++ b/src/DGDB.h
@@ -28,12 +28,8 @@ class DGDB {
 
   int port;
   std::string ip;
-  struct sockaddr_in stSockAddr;
   int connection;
   int server;
-  int socketServer;
-  int socketCliente;
-  int socketRepository; // se usa en el servidor respositorio
   char mode;
   int numberRepositories;
   int repository;

--- a/src/network/Network.h
+++ b/src/network/Network.h
@@ -103,6 +103,14 @@ class TCPSocket {
     }
   }
 
+  void Shutdown(int flags = 0) {
+    shutdown(sock, flags);
+  }
+
+  void Close() {
+    close(sock);
+  }
+
   int GetSocketId() {
     return sock;
   }


### PR DESCRIPTION
Changes:
- Replace hard-coded write commands in runConnection for TCPSocket logic
- Don't allow Init() twice on the same socket. Force use of RenewSocket()
- Use recv() instead of recvfrom in TCPSocket::Recv()